### PR TITLE
changed updating method to manual from automatic

### DIFF
--- a/ipcHandlers/system.js
+++ b/ipcHandlers/system.js
@@ -9,7 +9,7 @@ const pLimit = require("p-limit");
  * Register system-related IPC handlers
  * Includes: version info, OS data, node binary check, external URL opening
  */
-function registerSystemHandlers(nodeBinary) {
+function registerSystemHandlers(nodeBinary, checkForUpdatesManual) {
   ipcMain.handle('check-node', async () => {
     const testNodePath = path.join(process.resourcesPath, os.platform() === 'win32' ? 'node.exe' : 'node');
 
@@ -57,6 +57,8 @@ function registerSystemHandlers(nodeBinary) {
   });
 
   ipcMain.handle("get-p-limit", async () => pLimit);
+
+  ipcMain.handle("check-for-updates", async () => checkForUpdatesManual());
 }
 
 module.exports = {

--- a/lib/updater.js
+++ b/lib/updater.js
@@ -2,8 +2,9 @@ const { BrowserWindow, dialog } = require("electron");
 const { autoUpdater } = require("electron-updater");
 
 /**
- * Configure and set up the auto-updater
- * Checks for updates from GitHub releases on app startup
+ * Configure the auto-updater and register its event handlers
+ * Does not trigger a check itself — checks are only triggered manually
+ * via checkForUpdatesManual (wired to the Settings "Check For Updates" button)
  */
 function setupAutoUpdater() {
   autoUpdater.logger = require('electron-log');
@@ -21,17 +22,14 @@ function setupAutoUpdater() {
 
   autoUpdater.on('checking-for-update', () => {
     console.log('Checking for updates...');
-    BrowserWindow.getAllWindows()[0]?.webContents.send('update-status', 'Checking for updates...');
   });
 
   autoUpdater.on('update-available', (info) => {
     console.log('Update available:', info.version);
-    BrowserWindow.getAllWindows()[0].webContents.send('update-available', info);
   });
 
   autoUpdater.on('update-not-available', () => {
     console.log('No update available.');
-    BrowserWindow.getAllWindows()[0]?.webContents.send('update-not-available');
   });
 
   autoUpdater.on('update-downloaded', (info) => {
@@ -56,36 +54,55 @@ function setupAutoUpdater() {
 
   autoUpdater.on('error', (err) => {
     console.error('Auto-update error:', err);
-    BrowserWindow.getAllWindows()[0].webContents.send('update-error', err.message);
   });
 }
 
 /**
- * Trigger the update check
- * Called immediately when app is ready (runs in parallel with window creation)
- * Includes timeout to prevent hanging on slow connections
+ * Manually trigger an update check and resolve once the outcome is known.
+ * Backs the Settings "Check For Updates" button — the caller awaits this
+ * to know when to stop the loading spinner and what to tell the user.
  */
-function checkForUpdates() {
-  const UPDATE_CHECK_TIMEOUT = 10000; // 10 seconds
+function checkForUpdatesManual() {
+  const UPDATE_CHECK_TIMEOUT = 15000; // 15 seconds
 
-  let timeoutId = setTimeout(() => {
-    console.warn('[UPDATE] Update check timed out after 10 seconds. Continuing without update check.');
-    // Don't throw error, just log and continue - app should still work
-  }, UPDATE_CHECK_TIMEOUT);
+  return new Promise((resolve) => {
+    let settled = false;
 
-  autoUpdater.checkForUpdatesAndNotify()
-    .then(() => {
+    const cleanup = () => {
       clearTimeout(timeoutId);
-      console.log('[UPDATE] Update check completed successfully');
-    })
-    .catch((err) => {
-      clearTimeout(timeoutId);
+      autoUpdater.removeListener('update-available', onAvailable);
+      autoUpdater.removeListener('update-not-available', onNotAvailable);
+      autoUpdater.removeListener('error', onError);
+    };
+
+    const settle = (result) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const onAvailable = (info) => settle({ status: 'available', version: info.version });
+    const onNotAvailable = () => settle({ status: 'not-available' });
+    const onError = (err) => settle({ status: 'error', message: err.message });
+
+    const timeoutId = setTimeout(() => {
+      console.warn('[UPDATE] Update check timed out after 15 seconds.');
+      settle({ status: 'error', message: 'Update check timed out.' });
+    }, UPDATE_CHECK_TIMEOUT);
+
+    autoUpdater.once('update-available', onAvailable);
+    autoUpdater.once('update-not-available', onNotAvailable);
+    autoUpdater.once('error', onError);
+
+    autoUpdater.checkForUpdatesAndNotify().catch((err) => {
       console.error('[UPDATE] Update check failed:', err.message);
-      // Don't propagate error - app should continue even if update check fails
+      settle({ status: 'error', message: err.message });
     });
+  });
 }
 
 module.exports = {
   setupAutoUpdater,
-  checkForUpdates
+  checkForUpdatesManual
 };

--- a/lib/window.js
+++ b/lib/window.js
@@ -6,7 +6,7 @@ const path = require("path");
  * Create the main application window
  * Initializes logging, settings, and required directories
  */
-async function createWindow(initializeLogging, ensureDir, initializeSettings, migrateLegacySettings, isPackaged, isDev, getAuditsPath, checkForUpdates) {
+async function createWindow(initializeLogging, ensureDir, initializeSettings, migrateLegacySettings, isPackaged, isDev, getAuditsPath) {
   // Initialize logging system first
   await initializeLogging(ensureDir);
 
@@ -82,13 +82,8 @@ async function createWindow(initializeLogging, ensureDir, initializeSettings, mi
 /**
  * Set up app lifecycle event handlers
  */
-function setupAppLifecycle(createWindowFn, checkForUpdates) {
+function setupAppLifecycle(createWindowFn) {
   app.on("ready", () => {
-    // Start update check immediately in parallel with window creation
-    // This prevents slow window initialization from delaying the update notification
-    checkForUpdates();
-
-    // Create window (may take time on slower machines)
     createWindowFn();
   });
 

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const path = require("path");
 
 // ------------ Module Imports ------------
 const { initializeLogging, closeLogging, getLogFilePath } = require("./lib/logging");
-const { setupAutoUpdater, checkForUpdates } = require("./lib/updater");
+const { setupAutoUpdater, checkForUpdatesManual } = require("./lib/updater");
 const { ensureDir, initializeSettings } = require("./lib/initialization");
 const { getSettings, saveSettings, migrateLegacySettingsIfNeeded } = require("./lib/settingsStore");
 const { nodeBinary, chromiumPath, isPackaged, isDev, getAuditsPath, getSettingsPath, getResourcesPath } = require("./lib/paths");
@@ -55,16 +55,15 @@ const createWindowWrapper = () => {
     migrateLegacySettingsIfNeeded,
     isPackaged,
     isDev,
-    getAuditsPath,
-    checkForUpdates
+    getAuditsPath
   );
 };
 
 // Setup app lifecycle handlers
-setupAppLifecycle(createWindowWrapper, checkForUpdates);
+setupAppLifecycle(createWindowWrapper);
 
 // Register IPC handlers
-registerSystemHandlers(nodeBinary);
+registerSystemHandlers(nodeBinary, checkForUpdatesManual);
 registerFolderHandlers(isDev, getAuditsPath);
 registerFileHandlers(isDev, getAuditsPath, getSettingsPath, ensureDir);
 registerSettingsHandlers(getSettings, saveSettings);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FamilySearch-Automation-App",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "FamilySearch Automation Application",
   "main": "main.js",
   "author": "SolutionStream",

--- a/pages/SettingsMenu.jsx
+++ b/pages/SettingsMenu.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { VStack, HStack, Menu } from '@chakra-ui/react'
+import { VStack, HStack, Menu, Spinner } from '@chakra-ui/react'
 import CenteredHstackCss from '../reusables/CenteredHstackCss'
 import CenteredVstackCss from '../reusables/CenteredVstackCss'
 import MenuHeader from '../reusables/MenuHeader'
@@ -18,6 +18,8 @@ const SettingsMenu = () => {
   const [wikiButtonText, setWikiButtonText] = useState('Save Changes')
   const [urlButtonText, setUrlButtonText] = useState('Save Changes')
   const [keyButtonText, setKeyButtonText] = useState('Save Changes')
+  const [isCheckingUpdate, setIsCheckingUpdate] = useState(false)
+  const [updateStatusMessage, setUpdateStatusMessage] = useState('')
 
   const handleSave = async (key, value, setButtonText) => {
     const result = await updateSettings({ [key]: value })
@@ -25,6 +27,23 @@ const SettingsMenu = () => {
     setTimeout(() => {
       setButtonText('Save Changes')
     }, result.success ? 500 : 2000);
+  }
+
+  const handleCheckForUpdates = async () => {
+    setIsCheckingUpdate(true)
+    setUpdateStatusMessage('')
+
+    const result = await window.electronAPI.checkForUpdates()
+
+    if (result.status === 'available') {
+      setUpdateStatusMessage(`Update available! Version ${result.version} is downloading and will prompt you to install once ready.`)
+    } else if (result.status === 'not-available') {
+      setUpdateStatusMessage("You're on the latest version.")
+    } else {
+      setUpdateStatusMessage(`Couldn't check for updates: ${result.message}`)
+    }
+
+    setIsCheckingUpdate(false)
   }
 
   useEffect(() => {
@@ -43,11 +62,22 @@ const SettingsMenu = () => {
   return (
     <VStack {...CenteredVstackCss}>
         <MenuHeader title="Configuration" subTitle={`Version ${version}`} />
-        <LinkButton
-          destination="/view-logs"
-          buttonText="View Application Logs"
-          buttonClass="btn btn-extension btn-files"
-        />
+        <HStack {...CenteredHstackCss}>
+          <LinkButton
+            destination="/view-logs"
+            buttonText="View Application Logs"
+            buttonClass="btn btn-extension btn-files"
+          />
+          <button
+            className='btn btn-extension btn-files'
+            onClick={handleCheckForUpdates}
+            disabled={isCheckingUpdate}
+          >
+            {isCheckingUpdate && <Spinner size="sm" marginRight="8px" />}
+            {isCheckingUpdate ? 'Checking...' : 'Check For Updates'}
+          </button>
+        </HStack>
+        {updateStatusMessage && <p>{updateStatusMessage}</p>}
         <HStack {...CenteredHstackCss}>
           <VStack {...BodyVstackCss}>
               <h2>Base URL</h2>

--- a/preload.js
+++ b/preload.js
@@ -68,6 +68,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   getZendeskAuditResults: () => ipcRenderer.invoke("read-zendesk-audit-results"),
   getZendeskPathLineCount: (filename) => ipcRenderer.invoke("get-zendesk-path-line-count", filename),
   checkNode: () => ipcRenderer.invoke("check-node"),
+  checkForUpdates: () => ipcRenderer.invoke("check-for-updates"),
   // Logging functionality
   getLogFilePath: () => ipcRenderer.invoke("get-log-file-path"),
   readLogFile: () => ipcRenderer.invoke("read-log-file"),


### PR DESCRIPTION
Previously, patrons of this application were not able to detect with their computers that an update was available. This update removes the automatic checking of updates, and instead introduces a new button that manually checks upon patron input.
This solves the issue of some patrons not being able to detect at all that there's an update on their machines.